### PR TITLE
Minor fixes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,28 +14,30 @@ Using SoftBoundCETS with LLVM+CLANG-3.8.0 on a x86-64 machine with Linux OS
 
 2. Build SoftBoundCETS for LLVM+CLANG 3.8.0
 
-   1. Goto to directory llvm-38 by executing the following commands
-   
-            mkdir build; cd build
+   1. Go to directory <git_repo>/llvm-38/ and execute the following commands
+      ```
+      mkdir build; cd build
+      ```
 
-   2. Configure and build  LLVM, clang and softboundcets with the following commands
-
-            cmake ../llvm-38/
-	    make -j8
-
+   2. Configure and build LLVM, clang and softboundcets with the following commands
+      ```
+      cmake ..
+      make -j8
+      ```
 
 3. Set up your environment to use SoftBoundCETS
 
    For example in bash, it would be
-
-         export PATH=<git_repo>/softboundcets-llvm-3.8.0/build/bin:$PATH
-
+   ```
+   export PATH=<git_repo>/llvm-38/build/bin:$PATH
+   ```
 
 4. Compile the SoftBoundCETS runtime library
-
-         cd <git_repo>
-         cd runtime
-         make
+   ```
+   cd <git_repo>
+   cd runtime
+   make
+   ```
 
    If you compiled the LLVM gold plugin, add the line below before calling
    make, in order to also build the SoftBoundCETS runtime library with LTO
@@ -45,15 +47,17 @@ Using SoftBoundCETS with LLVM+CLANG-3.8.0 on a x86-64 machine with Linux OS
 5. Test whether it all worked
 
    1. Compile
-
-       cd tests
-       clang -fsoftboundcets test.c -o test -L<git_repo>/softboundcets-lib -lm -lrt -lsoftboundcets_rt
-       clang -fsoftboundcets -flto test.c -o test-lto -L<git_repo>/softboundcets-lib/lto -lm -lrt -lsoftboundcets_r\
-t
+      ```
+      cd <git_repo>
+      cd test
+      clang -fsoftboundcets test.c -o test -L<git_repo>/runtime -lm -lrt -lsoftboundcets_rt
+      clang -fsoftboundcets -flto test.c -o test-lto -L<git_repo>/runtime/lto -lm -lrt -lsoftboundcets_rt
+      ```
 
    2. Run the test program
-
-            ./test
+      ```
+      ./test
+      ```
 
       Enter 10; the program executes successfully.
 


### PR DESCRIPTION
I'm proposing some minor changes to README.md that fix some typos and some things that are obsolete or confusing. (I made the edits as I was following the instructions.) I also added some code block formatters to ensure the shell commands are correctly formatted. In one case, I missed the `make -j8` command because it was formatted differently from the `cmake` line.
